### PR TITLE
feat: add install-tools.sh and auto-fix compinit permissions

### DIFF
--- a/install-tools.sh
+++ b/install-tools.sh
@@ -39,7 +39,7 @@ install_linux() {
         echo "Created symlink: $HOME/.local/bin/fd -> $(command -v fdfind)"
       fi
     fi
-    if ! printf '%s\n' "$PATH" | grep -q "$HOME/.local/bin"; then
+    if ! printf '%s\n' "$PATH" | grep -F -q -- "$HOME/.local/bin"; then
       echo "Note: $HOME/.local/bin is not in your PATH. Add it to use 'bat' and 'fd' directly."
     fi
     # Try apt first (available in some Ubuntu versions/added repos), then fall back to cargo

--- a/install-tools.sh
+++ b/install-tools.sh
@@ -29,12 +29,15 @@ install_linux() {
   if ! printf '%s\n' "$PATH" | grep -q "$HOME/.local/bin"; then
     echo "Note: $HOME/.local/bin is not in your PATH. Add it to use 'bat' and 'fd' directly."
   fi
-  # eza is not in default apt repos on Ubuntu 24.04 — install via cargo or deb
+  # Try apt first (available in some Ubuntu versions/added repos), then fall back to cargo
   if ! command -v eza &>/dev/null; then
-    if command -v cargo &>/dev/null; then
+    if sudo apt-get install -y eza; then
+      echo "eza installed via apt"
+    elif command -v cargo &>/dev/null; then
+      echo "eza not available via apt, installing via cargo..."
       cargo install eza
     else
-      echo "eza: install cargo (rustup) then re-run, or download from https://github.com/eza-community/eza/releases"
+      echo "eza: not available via apt. Install cargo (rustup) then re-run, or download from https://github.com/eza-community/eza/releases"
     fi
   fi
 }

--- a/install-tools.sh
+++ b/install-tools.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# install-tools.sh — Install recommended CLI tools based on OS
+
+set -e
+
+install_macos() {
+  if ! command -v brew &>/dev/null; then
+    echo "Homebrew not found. Install it first: https://brew.sh"
+    exit 1
+  fi
+  brew install fzf zoxide eza bat fd ripgrep neovim
+}
+
+install_linux() {
+  sudo apt-get update -y
+  # bat is 'batcat' and fd is 'fdfind' on Debian/Ubuntu
+  sudo apt-get install -y fzf bat fd-find ripgrep neovim
+
+  # eza is not in default apt repos on Ubuntu 24.04 — install via cargo or deb
+  if ! command -v eza &>/dev/null; then
+    if command -v cargo &>/dev/null; then
+      cargo install eza
+    else
+      echo "eza: install cargo (rustup) then re-run, or download from https://github.com/eza-community/eza/releases"
+    fi
+  fi
+
+  # zoxide
+  if ! command -v zoxide &>/dev/null; then
+    curl -sSfL https://raw.githubusercontent.com/ajeetdsouza/zoxide/main/install.sh | sh
+  fi
+}
+
+case "$(uname)" in
+  Darwin)   install_macos ;;
+  Linux)    install_linux ;;
+  *)        echo "Unsupported OS: $(uname)"; exit 1 ;;
+esac
+
+echo "Done. Restart your shell or run: source ~/.zshrc"

--- a/install-tools.sh
+++ b/install-tools.sh
@@ -12,33 +12,59 @@ install_macos() {
 }
 
 install_linux() {
-  sudo apt-get update -y
-  # bat is 'batcat' and fd is 'fdfind' on Debian/Ubuntu
-  sudo apt-get install -y fzf bat fd-find ripgrep neovim zoxide
+  if command -v apt-get &>/dev/null; then
+    sudo apt-get update -y
+    # bat is 'batcat' and fd is 'fdfind' on Debian/Ubuntu
+    sudo apt-get install -y fzf bat fd-find ripgrep neovim zoxide
 
-  # Ensure bat/fd commands exist for consistency with macOS and docs
-  mkdir -p "$HOME/.local/bin"
-  if command -v batcat &>/dev/null && [ ! -e "$HOME/.local/bin/bat" ]; then
-    ln -s "$(command -v batcat)" "$HOME/.local/bin/bat"
-    echo "Created symlink: $HOME/.local/bin/bat -> $(command -v batcat)"
-  fi
-  if command -v fdfind &>/dev/null && [ ! -e "$HOME/.local/bin/fd" ]; then
-    ln -s "$(command -v fdfind)" "$HOME/.local/bin/fd"
-    echo "Created symlink: $HOME/.local/bin/fd -> $(command -v fdfind)"
-  fi
-  if ! printf '%s\n' "$PATH" | grep -q "$HOME/.local/bin"; then
-    echo "Note: $HOME/.local/bin is not in your PATH. Add it to use 'bat' and 'fd' directly."
-  fi
-  # Try apt first (available in some Ubuntu versions/added repos), then fall back to cargo
-  if ! command -v eza &>/dev/null; then
-    if sudo apt-get install -y eza; then
-      echo "eza installed via apt"
-    elif command -v cargo &>/dev/null; then
-      echo "eza not available via apt, installing via cargo..."
-      cargo install eza
-    else
-      echo "eza: not available via apt. Install cargo (rustup) then re-run, or download from https://github.com/eza-community/eza/releases"
+    # Ensure bat/fd commands exist for consistency with macOS and docs
+    mkdir -p "$HOME/.local/bin"
+    if command -v batcat &>/dev/null; then
+      # Remove broken bat symlink if it exists, so ln -s won't fail under set -e
+      if [ -L "$HOME/.local/bin/bat" ] && [ ! -e "$HOME/.local/bin/bat" ]; then
+        rm "$HOME/.local/bin/bat"
+      fi
+      if [ ! -e "$HOME/.local/bin/bat" ]; then
+        ln -s "$(command -v batcat)" "$HOME/.local/bin/bat"
+        echo "Created symlink: $HOME/.local/bin/bat -> $(command -v batcat)"
+      fi
     fi
+    if command -v fdfind &>/dev/null; then
+      # Remove broken fd symlink if it exists, so ln -s won't fail under set -e
+      if [ -L "$HOME/.local/bin/fd" ] && [ ! -e "$HOME/.local/bin/fd" ]; then
+        rm "$HOME/.local/bin/fd"
+      fi
+      if [ ! -e "$HOME/.local/bin/fd" ]; then
+        ln -s "$(command -v fdfind)" "$HOME/.local/bin/fd"
+        echo "Created symlink: $HOME/.local/bin/fd -> $(command -v fdfind)"
+      fi
+    fi
+    if ! printf '%s\n' "$PATH" | grep -q "$HOME/.local/bin"; then
+      echo "Note: $HOME/.local/bin is not in your PATH. Add it to use 'bat' and 'fd' directly."
+    fi
+    # Try apt first (available in some Ubuntu versions/added repos), then fall back to cargo
+    if ! command -v eza &>/dev/null; then
+      if sudo apt-get install -y eza; then
+        echo "eza installed via apt"
+      elif command -v cargo &>/dev/null; then
+        echo "eza not available via apt, installing via cargo..."
+        cargo install eza
+      else
+        echo "eza: not available via apt. Install cargo (rustup) then re-run, or download from https://github.com/eza-community/eza/releases"
+      fi
+    fi
+  else
+    echo "Unsupported Linux distribution for this installer."
+    echo "This script currently supports Debian/Ubuntu systems with apt-get."
+    echo "Please install the following tools using your distribution's package manager:"
+    echo "  - fzf"
+    echo "  - zoxide"
+    echo "  - eza"
+    echo "  - bat"
+    echo "  - fd"
+    echo "  - ripgrep"
+    echo "  - neovim"
+    exit 1
   fi
 }
 

--- a/install-tools.sh
+++ b/install-tools.sh
@@ -16,6 +16,19 @@ install_linux() {
   # bat is 'batcat' and fd is 'fdfind' on Debian/Ubuntu
   sudo apt-get install -y fzf bat fd-find ripgrep neovim zoxide
 
+  # Ensure bat/fd commands exist for consistency with macOS and docs
+  mkdir -p "$HOME/.local/bin"
+  if command -v batcat &>/dev/null && [ ! -e "$HOME/.local/bin/bat" ]; then
+    ln -s "$(command -v batcat)" "$HOME/.local/bin/bat"
+    echo "Created symlink: $HOME/.local/bin/bat -> $(command -v batcat)"
+  fi
+  if command -v fdfind &>/dev/null && [ ! -e "$HOME/.local/bin/fd" ]; then
+    ln -s "$(command -v fdfind)" "$HOME/.local/bin/fd"
+    echo "Created symlink: $HOME/.local/bin/fd -> $(command -v fdfind)"
+  fi
+  if ! printf '%s\n' "$PATH" | grep -q "$HOME/.local/bin"; then
+    echo "Note: $HOME/.local/bin is not in your PATH. Add it to use 'bat' and 'fd' directly."
+  fi
   # eza is not in default apt repos on Ubuntu 24.04 — install via cargo or deb
   if ! command -v eza &>/dev/null; then
     if command -v cargo &>/dev/null; then

--- a/install-tools.sh
+++ b/install-tools.sh
@@ -14,7 +14,7 @@ install_macos() {
 install_linux() {
   sudo apt-get update -y
   # bat is 'batcat' and fd is 'fdfind' on Debian/Ubuntu
-  sudo apt-get install -y fzf bat fd-find ripgrep neovim
+  sudo apt-get install -y fzf bat fd-find ripgrep neovim zoxide
 
   # eza is not in default apt repos on Ubuntu 24.04 — install via cargo or deb
   if ! command -v eza &>/dev/null; then
@@ -23,11 +23,6 @@ install_linux() {
     else
       echo "eza: install cargo (rustup) then re-run, or download from https://github.com/eza-community/eza/releases"
     fi
-  fi
-
-  # zoxide
-  if ! command -v zoxide &>/dev/null; then
-    curl -sSfL https://raw.githubusercontent.com/ajeetdsouza/zoxide/main/install.sh | sh
   fi
 }
 

--- a/zshrc
+++ b/zshrc
@@ -44,6 +44,7 @@ if [[ -n $insecure_compdirs ]]; then
   done
 fi
 unset insecure_compdirs
+unset insecure_compdirs
 
 # Enable completions
 autoload -U +X bashcompinit && bashcompinit

--- a/zshrc
+++ b/zshrc
@@ -34,6 +34,11 @@ fi
 # Prompt initialization
 autoload -Uz promptinit && promptinit && prompt powerlevel10k
 
+# Auto-fix insecure compinit directories
+if [[ -n $(compaudit 2>/dev/null) ]]; then
+  compaudit 2>/dev/null | xargs chmod g-w 2>/dev/null
+fi
+
 # Enable completions
 autoload -U +X bashcompinit && bashcompinit
 autoload -U +X compinit && compinit

--- a/zshrc
+++ b/zshrc
@@ -35,8 +35,10 @@ fi
 autoload -Uz promptinit && promptinit && prompt powerlevel10k
 
 # Auto-fix insecure compinit directories
-if [[ -n $(compaudit 2>/dev/null) ]]; then
-  compaudit 2>/dev/null | xargs chmod g-w 2>/dev/null
+autoload -Uz compaudit
+insecure_compdirs=$(compaudit 2>/dev/null)
+if [[ -n $insecure_compdirs ]]; then
+  printf '%s\n' "$insecure_compdirs" | xargs chmod go-w 2>/dev/null
 fi
 
 # Enable completions

--- a/zshrc
+++ b/zshrc
@@ -34,12 +34,16 @@ fi
 # Prompt initialization
 autoload -Uz promptinit && promptinit && prompt powerlevel10k
 
-# Auto-fix insecure compinit directories
+# Auto-fix insecure compinit directories (restrict to $HOME only)
 autoload -Uz compaudit
 insecure_compdirs=$(compaudit 2>/dev/null)
 if [[ -n $insecure_compdirs ]]; then
-  printf '%s\n' "$insecure_compdirs" | xargs chmod go-w 2>/dev/null
+  printf '%s\n' "$insecure_compdirs" | while IFS= read -r dir; do
+    [[ $dir == "$HOME" || $dir == "$HOME"/* ]] || continue
+    chmod g-w "$dir" 2>/dev/null
+  done
 fi
+unset insecure_compdirs
 
 # Enable completions
 autoload -U +X bashcompinit && bashcompinit

--- a/zshrc
+++ b/zshrc
@@ -39,7 +39,7 @@ autoload -Uz compaudit
 insecure_compdirs=$(compaudit 2>/dev/null)
 if [[ -n $insecure_compdirs ]]; then
   printf '%s\n' "$insecure_compdirs" | while IFS= read -r dir; do
-    [[ $dir == "$HOME" || $dir == "$HOME"/* ]] || continue
+    [[ $dir == "$HOME" || $dir == $HOME/* ]] || continue
     chmod g-w "$dir" 2>/dev/null
   done
 fi


### PR DESCRIPTION
Add install-tools.sh to install recommended CLI tools (fzf, zoxide, eza, bat, fd, ripgrep, neovim) on macOS via Homebrew or Linux via apt/cargo.

Add compaudit/chmod fix in zshrc before compinit so insecure directories are silently corrected on every shell startup.