### PR TITLE
feat: add warning message when antidote is not installed

### DIFF
--- a/zshrc
+++ b/zshrc
@@ -27,9 +27,11 @@ if [[ -f ${ZDOTDIR:-~}/.antidote/antidote.zsh ]]; then
   source ${ZDOTDIR:-~}/.antidote/antidote.zsh
   antidote load
 else
-  echo "Warning: Antidote plugin manager not found."
-  echo "  Install with: git clone --depth=1 https://github.com/mattmc3/antidote.git ~/.antidote"
-  echo "  Or run: ./install.sh"
+  if [[ -o interactive ]]; then
+    print -u2 -- "Warning: Antidote plugin manager not found."
+    print -u2 -- "  Install with: git clone --depth=1 https://github.com/mattmc3/antidote.git ${ZDOTDIR:-~}/.antidote"
+    print -u2 -- "  Or from your dotfiles directory, run: ./install.sh"
+  fi
 fi
 
 # ============================================================================

--- a/zshrc
+++ b/zshrc
@@ -26,6 +26,10 @@ ZSH_DISABLE_COMPFIX=true
 if [[ -f ${ZDOTDIR:-~}/.antidote/antidote.zsh ]]; then
   source ${ZDOTDIR:-~}/.antidote/antidote.zsh
   antidote load
+else
+  echo "Warning: Antidote plugin manager not found."
+  echo "  Install with: git clone --depth=1 https://github.com/mattmc3/antidote.git ~/.antidote"
+  echo "  Or run: ./install.sh"
 fi
 
 # ============================================================================

--- a/zshrc
+++ b/zshrc
@@ -29,7 +29,7 @@ if [[ -f ${ZDOTDIR:-~}/.antidote/antidote.zsh ]]; then
 else
   if [[ -o interactive ]]; then
     print -u2 -- "Warning: Antidote plugin manager not found."
-    print -u2 -- "  Install with: git clone --depth=1 https://github.com/mattmc3/antidote.git ${ZDOTDIR:-~}/.antidote"
+    print -u2 -- "  Install with: git clone --depth=1 https://github.com/mattmc3/antidote.git \"${ZDOTDIR:-~}/.antidote\""
     print -u2 -- "  Or from your dotfiles directory, run: ./install.sh"
   fi
 fi


### PR DESCRIPTION
## Summary
- Print a clear warning with install instructions when antidote plugin manager is not found
- Directs users to either the manual git clone command or `./install.sh`

## Test plan
- [ ] Temporarily rename `~/.antidote` and open a new shell — warning should appear
- [ ] Restore `~/.antidote` and open a new shell — no warning, plugins load normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)