### PR TITLE
nvim: add neo-tree file explorer with <leader>n toggle

### DIFF
--- a/nvim/init.lua
+++ b/nvim/init.lua
@@ -221,20 +221,25 @@ vim.keymap.set('n', '<leader>sg', require('telescope.builtin').live_grep, { desc
 vim.keymap.set('n', '<leader>sd', require('telescope.builtin').diagnostics, { desc = '[S]earch [D]iagnostics' })
 
 -- [[ Configure Neo-tree ]]
--- File system browser / directory tree
-require('neo-tree').setup {
-  close_if_last_window = true, -- close the tree if it is the only window left
-  enable_git_status = true,
-  enable_diagnostics = true,
-  window = {
-    position = 'left',
-    width = 40,
-  },
-  filesystem = {
-    follow_current_file = { enabled = true }, -- reveal the current file in the tree
-    use_libuv_file_watcher = true, -- update the tree as files change on disk
-  },
-}
+-- File system browser / directory tree.
+-- Guard with pcall so a fresh checkout (before :PackerSync) doesn't break the
+-- rest of init.lua if the plugin isn't installed yet.
+local has_neotree, neotree = pcall(require, 'neo-tree')
+if has_neotree then
+  neotree.setup {
+    close_if_last_window = true, -- close the tree if it is the only window left
+    enable_git_status = true,
+    enable_diagnostics = true,
+    window = {
+      position = 'left',
+      width = 40,
+    },
+    filesystem = {
+      follow_current_file = { enabled = true }, -- reveal the current file in the tree
+      use_libuv_file_watcher = true, -- update the tree as files change on disk
+    },
+  }
+end
 
 -- Toggle the directory tree (restores the old NERDTree muscle memory)
 vim.keymap.set('n', '<leader>n', '<cmd>Neotree toggle<CR>', { desc = 'Toggle [N]eo-tree' })

--- a/nvim/init.lua
+++ b/nvim/init.lua
@@ -53,6 +53,17 @@ require('packer').startup(function(use)
   -- Fuzzy Finder Algorithm which requires local dependencies to be built. Only load if `make` is available
   use { 'nvim-telescope/telescope-fzf-native.nvim', run = 'make', cond = vim.fn.executable 'make' == 1 }
 
+  -- File system browser / directory tree
+  use {
+    'nvim-neo-tree/neo-tree.nvim',
+    branch = 'v3.x',
+    requires = {
+      'nvim-lua/plenary.nvim',
+      'MunifTanjim/nui.nvim',
+      'nvim-tree/nvim-web-devicons', -- optional, but recommended for icons
+    },
+  }
+
   -- Add custom plugins to packer from ~/.config/nvim/lua/custom/plugins.lua
   local has_plugins, plugins = pcall(require, 'custom.plugins')
   if has_plugins then
@@ -208,6 +219,25 @@ vim.keymap.set('n', '<leader>sh', require('telescope.builtin').help_tags, { desc
 vim.keymap.set('n', '<leader>sw', require('telescope.builtin').grep_string, { desc = '[S]earch current [W]ord' })
 vim.keymap.set('n', '<leader>sg', require('telescope.builtin').live_grep, { desc = '[S]earch by [G]rep' })
 vim.keymap.set('n', '<leader>sd', require('telescope.builtin').diagnostics, { desc = '[S]earch [D]iagnostics' })
+
+-- [[ Configure Neo-tree ]]
+-- File system browser / directory tree
+require('neo-tree').setup {
+  close_if_last_window = true, -- close the tree if it is the only window left
+  enable_git_status = true,
+  enable_diagnostics = true,
+  window = {
+    position = 'left',
+    width = 40,
+  },
+  filesystem = {
+    follow_current_file = { enabled = true }, -- reveal the current file in the tree
+    use_libuv_file_watcher = true, -- update the tree as files change on disk
+  },
+}
+
+-- Toggle the directory tree (restores the old NERDTree muscle memory)
+vim.keymap.set('n', '<leader>n', '<cmd>Neotree toggle<CR>', { desc = 'Toggle [N]eo-tree' })
 
 -- [[ Configure Treesitter ]]
 -- nvim-treesitter v1.0+: highlight/indent are built-in to Neovim 0.12+.


### PR DESCRIPTION
## What

Adds [neo-tree.nvim](https://github.com/nvim-neo-tree/neo-tree.nvim) (v3.x) as the directory-tree / file explorer for the Neovim config, replacing the long-gone NERDTree that only lived in the retired `init.old.vim`.

## Details

- Declares the plugin in the packer block with its deps: `nui.nvim` and `nvim-web-devicons` (`plenary.nvim` was already present for Telescope).
- `require('neo-tree').setup{}`: 40-column left sidebar, git status + diagnostics, reveals the current file, and uses libuv to watch the filesystem for changes.
- Binds `<leader>n` (Space n) to `:Neotree toggle`, restoring the NERDTree muscle memory from `init.old.vim`.

## Activating

After merge + pulling, run `:PackerSync` in nvim to install neo-tree and its deps, then restart. `Space n` toggles the tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)